### PR TITLE
feat(dashboard): DifficultyBreakdown + BadgeDisplay; integrate into dashboard

### DIFF
--- a/src/components/dashboard/BadgeDisplay.tsx
+++ b/src/components/dashboard/BadgeDisplay.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+
+interface BadgeDisplayProps {
+  completedCount: number;
+  completedIds: string[];
+  mountains: Array<{
+    id: string;
+    difficulty: string;
+  }>;
+}
+
+interface Badge {
+  key: string;
+  title: string;
+  description: string;
+  icon: string;
+  condition: boolean;
+}
+
+export default function BadgeDisplay({ completedCount, completedIds, mountains }: BadgeDisplayProps) {
+  // Check if user has completed any 5-star mountain
+  const hasFiveStarMountain = mountains.some(mountain => 
+    mountain.difficulty === '★★★★' && completedIds.includes(mountain.id)
+  );
+
+  const badges: Badge[] = [
+    {
+      key: 'first_step',
+      title: 'First Step',
+      description: 'Complete your first mountain',
+      icon: '🏔️',
+      condition: completedCount >= 1
+    },
+    {
+      key: 'ten_done',
+      title: 'Ten Done',
+      description: 'Complete 10 mountains',
+      icon: '🎯',
+      condition: completedCount >= 10
+    },
+    {
+      key: 'half_way',
+      title: 'Half Way',
+      description: 'Complete 50 mountains',
+      icon: '🏆',
+      condition: completedCount >= 50
+    },
+    {
+      key: 'five_star_climber',
+      title: 'Five Star Climber',
+      description: 'Complete a 5-star mountain',
+      icon: '⭐',
+      condition: hasFiveStarMountain
+    }
+  ];
+
+  const earnedBadges = badges.filter(badge => badge.condition);
+  const lockedBadges = badges.filter(badge => !badge.condition);
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-md">
+      <h3 className="text-lg font-semibold text-gray-800 mb-4">Achievements</h3>
+      
+      {earnedBadges.length > 0 && (
+        <div className="mb-4">
+          <h4 className="text-sm font-medium text-gray-600 mb-2">Earned</h4>
+          <div className="grid grid-cols-2 gap-3">
+            {earnedBadges.map((badge) => (
+              <div
+                key={badge.key}
+                className="flex items-center space-x-3 p-3 bg-green-50 border border-green-200 rounded-lg"
+              >
+                <span className="text-2xl">{badge.icon}</span>
+                <div>
+                  <div className="text-sm font-medium text-green-800">{badge.title}</div>
+                  <div className="text-xs text-green-600">{badge.description}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {lockedBadges.length > 0 && (
+        <div>
+          <h4 className="text-sm font-medium text-gray-600 mb-2">Locked</h4>
+          <div className="grid grid-cols-2 gap-3">
+            {lockedBadges.map((badge) => (
+              <div
+                key={badge.key}
+                className="flex items-center space-x-3 p-3 bg-gray-50 border border-gray-200 rounded-lg opacity-60"
+              >
+                <span className="text-2xl grayscale">{badge.icon}</span>
+                <div>
+                  <div className="text-sm font-medium text-gray-500">{badge.title}</div>
+                  <div className="text-xs text-gray-400">{badge.description}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {earnedBadges.length === 0 && (
+        <div className="text-center py-4">
+          <div className="text-gray-400 text-sm">Complete mountains to earn achievements!</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/DifficultyBreakdown.tsx
+++ b/src/components/dashboard/DifficultyBreakdown.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+interface DifficultyBreakdownProps {
+  mountains: Array<{
+    id: string;
+    difficulty: string;
+  }>;
+  completedIds: string[];
+}
+
+export default function DifficultyBreakdown({ mountains, completedIds }: DifficultyBreakdownProps) {
+  // Calculate difficulty statistics
+  const difficultyStats = mountains.reduce((acc, mountain) => {
+    const difficulty = mountain.difficulty || '★';
+    const isCompleted = completedIds.includes(mountain.id);
+    
+    if (!acc[difficulty]) {
+      acc[difficulty] = { total: 0, completed: 0 };
+    }
+    
+    acc[difficulty].total++;
+    if (isCompleted) {
+      acc[difficulty].completed++;
+    }
+    
+    return acc;
+  }, {} as Record<string, { total: number; completed: number }>);
+
+  // Define difficulty order (1-4 stars)
+  const difficultyOrder = ['★', '★★', '★★★', '★★★★'];
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-md">
+      <h3 className="text-lg font-semibold text-gray-800 mb-4">Progress by Difficulty</h3>
+      <div className="space-y-3">
+        {difficultyOrder.map((difficulty) => {
+          const stats = difficultyStats[difficulty];
+          if (!stats) return null;
+          
+          const percentage = stats.total > 0 ? (stats.completed / stats.total) * 100 : 0;
+          
+          return (
+            <div key={difficulty} className="space-y-1">
+              <div className="flex justify-between items-center">
+                <span className="text-sm font-medium text-gray-700">
+                  {difficulty} ({stats.completed}/{stats.total})
+                </span>
+                <span className="text-xs text-gray-500">
+                  {Math.round(percentage)}%
+                </span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-2">
+                <div
+                  className="bg-indigo-600 h-2 rounded-full transition-all duration-300"
+                  style={{ width: `${percentage}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What was implemented
- DifficultyBreakdown: progress bars per difficulty (★, ★★, ★★★, ★★★★), shows counts and %
- BadgeDisplay: First Step, Ten Done, Half Way, Five Star Climber (earned=green, locked=gray)
- Dashboard integration: both components added in a responsive 2-col grid
- Type updates: Mountain interface includes `difficulty`
- Data: uses real mountains data via useMountainCompletions; real-time updates on toggle

## How to test
1) `pnpm dev` and open /dashboard
2) Toggle completions; verify:
   - Difficulty bars update instantly with counts and percentages
   - Badges unlock appropriately by total completions and difficulty thresholds
   - Layout stays responsive (2 cols on lg screens, stacks on small)

## Screens/Notes
- Visual feedback: Progress bars and badges clearly indicate progress
- Type safety: All components TypeScript-typed
