### PR TITLE
fix: Remove strike-through effect from completed mountain names

### DIFF
--- a/src/components/dashboard/MountainName.tsx
+++ b/src/components/dashboard/MountainName.tsx
@@ -10,7 +10,6 @@ export default function MountainName({ nameJa, done }: MountainNameProps) {
       style={{
         color: done ? '#16a34a' : '#6b7280',
         fontWeight: done ? 'bold' : 'normal',
-        textDecoration: done ? 'line-through' : 'none',
         fontSize: '1.125rem',
         transition: 'all 0.2s ease'
       }}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -35,7 +35,6 @@ body {
 .mountain-name.completed {
   color: #16a34a;
   font-weight: bold;
-  text-decoration: line-through;
 }
 
 .mountain-name.not-completed {


### PR DESCRIPTION
- Remove text-decoration: line-through from .mountain-name.completed CSS class
- Remove textDecoration: line-through from MountainName component inline styles
- Preserve green color (#16a34a) and bold font weight for completed mountains
- Mountain names now show as green and bold without strike-through when completed