### PR TITLE
feat: Add comprehensive language translations for dashboard components

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -232,7 +232,7 @@ export default function Dashboard() {
             return (
               <div key={region} className="space-y-4">
                 <h2 className="text-2xl font-bold text-gray-800 border-b-2 border-indigo-200 pb-2">
-                  {region}
+                  {t(`regions.${region}`)}
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                   {mountains.map((mountain) => (

--- a/src/components/dashboard/BadgeDisplay.tsx
+++ b/src/components/dashboard/BadgeDisplay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslations } from 'next-intl';
 
 interface BadgeDisplayProps {
   completedCount: number;
@@ -18,6 +19,8 @@ interface Badge {
 }
 
 export default function BadgeDisplay({ completedCount, completedIds, mountains }: BadgeDisplayProps) {
+  const t = useTranslations();
+  
   // Check if user has completed any 5-star mountain
   const hasFiveStarMountain = mountains.some(mountain => 
     mountain.difficulty === '★★★★' && completedIds.includes(mountain.id)
@@ -26,29 +29,29 @@ export default function BadgeDisplay({ completedCount, completedIds, mountains }
   const badges: Badge[] = [
     {
       key: 'first_step',
-      title: 'First Step',
-      description: 'Complete your first mountain',
+      title: t('badges.firstStep.title'),
+      description: t('badges.firstStep.description'),
       icon: '🏔️',
       condition: completedCount >= 1
     },
     {
       key: 'ten_done',
-      title: 'Ten Done',
-      description: 'Complete 10 mountains',
+      title: t('badges.tenDone.title'),
+      description: t('badges.tenDone.description'),
       icon: '🎯',
       condition: completedCount >= 10
     },
     {
       key: 'half_way',
-      title: 'Half Way',
-      description: 'Complete 50 mountains',
+      title: t('badges.halfWay.title'),
+      description: t('badges.halfWay.description'),
       icon: '🏆',
       condition: completedCount >= 50
     },
     {
       key: 'five_star_climber',
-      title: 'Five Star Climber',
-      description: 'Complete a 5-star mountain',
+      title: t('badges.fiveStarClimber.title'),
+      description: t('badges.fiveStarClimber.description'),
       icon: '⭐',
       condition: hasFiveStarMountain
     }
@@ -59,11 +62,11 @@ export default function BadgeDisplay({ completedCount, completedIds, mountains }
 
   return (
     <div className="bg-white p-6 rounded-lg shadow-md">
-      <h3 className="text-lg font-semibold text-gray-800 mb-4">Achievements</h3>
+      <h3 className="text-lg font-semibold text-gray-800 mb-4">{t('achievements')}</h3>
       
       {earnedBadges.length > 0 && (
         <div className="mb-4">
-          <h4 className="text-sm font-medium text-gray-600 mb-2">Earned</h4>
+          <h4 className="text-sm font-medium text-gray-600 mb-2">{t('earned')}</h4>
           <div className="grid grid-cols-2 gap-3">
             {earnedBadges.map((badge) => (
               <div
@@ -83,7 +86,7 @@ export default function BadgeDisplay({ completedCount, completedIds, mountains }
 
       {lockedBadges.length > 0 && (
         <div>
-          <h4 className="text-sm font-medium text-gray-600 mb-2">Locked</h4>
+          <h4 className="text-sm font-medium text-gray-600 mb-2">{t('locked')}</h4>
           <div className="grid grid-cols-2 gap-3">
             {lockedBadges.map((badge) => (
               <div
@@ -103,7 +106,7 @@ export default function BadgeDisplay({ completedCount, completedIds, mountains }
 
       {earnedBadges.length === 0 && (
         <div className="text-center py-4">
-          <div className="text-gray-400 text-sm">Complete mountains to earn achievements!</div>
+          <div className="text-gray-400 text-sm">{t('completeMountainsToEarn')}</div>
         </div>
       )}
     </div>

--- a/src/components/dashboard/DifficultyBreakdown.tsx
+++ b/src/components/dashboard/DifficultyBreakdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslations } from 'next-intl';
 
 interface DifficultyBreakdownProps {
   mountains: Array<{
@@ -9,6 +10,8 @@ interface DifficultyBreakdownProps {
 }
 
 export default function DifficultyBreakdown({ mountains, completedIds }: DifficultyBreakdownProps) {
+  const t = useTranslations();
+  
   // Calculate difficulty statistics
   const difficultyStats = mountains.reduce((acc, mountain) => {
     const difficulty = mountain.difficulty || '★';
@@ -31,7 +34,7 @@ export default function DifficultyBreakdown({ mountains, completedIds }: Difficu
 
   return (
     <div className="bg-white p-6 rounded-lg shadow-md">
-      <h3 className="text-lg font-semibold text-gray-800 mb-4">Progress by Difficulty</h3>
+      <h3 className="text-lg font-semibold text-gray-800 mb-4">{t('progressByDifficulty')}</h3>
       <div className="space-y-3">
         {difficultyOrder.map((difficulty) => {
           const stats = difficultyStats[difficulty];

--- a/src/lib/i18n/messages/en.json
+++ b/src/lib/i18n/messages/en.json
@@ -13,5 +13,38 @@
   "dateSetToToday": "Date set to today. You can edit it.",
   "dateInvalidFuture": "Date can't be in the future",
   "dateSaved": "Date saved successfully",
-  "dateCleared": "Date cleared"
+  "dateCleared": "Date cleared",
+  "progressByDifficulty": "Progress by Difficulty",
+  "achievements": "Achievements",
+  "earned": "Earned",
+  "locked": "Locked",
+  "completeMountainsToEarn": "Complete mountains to earn achievements!",
+  "badges": {
+    "firstStep": {
+      "title": "First Step",
+      "description": "Complete your first mountain"
+    },
+    "tenDone": {
+      "title": "Ten Done",
+      "description": "Complete 10 mountains"
+    },
+    "halfWay": {
+      "title": "Half Way",
+      "description": "Complete 50 mountains"
+    },
+    "fiveStarClimber": {
+      "title": "Five Star Climber",
+      "description": "Complete a 5-star mountain"
+    }
+  },
+  "regions": {
+    "北海道": "Hokkaido",
+    "東北": "Tohoku",
+    "関東": "Kanto",
+    "中部": "Chubu",
+    "関西": "Kansai",
+    "中国": "Chugoku",
+    "四国": "Shikoku",
+    "九州": "Kyushu"
+  }
 }

--- a/src/lib/i18n/messages/ja.json
+++ b/src/lib/i18n/messages/ja.json
@@ -13,5 +13,38 @@
   "dateSetToToday": "今日の日付が設定されました。編集できます。",
   "dateInvalidFuture": "未来の日付は設定できません",
   "dateSaved": "日付が保存されました",
-  "dateCleared": "日付がクリアされました"
+  "dateCleared": "日付がクリアされました",
+  "progressByDifficulty": "難易度別進捗",
+  "achievements": "実績",
+  "earned": "獲得済み",
+  "locked": "未獲得",
+  "completeMountainsToEarn": "山を登って実績を獲得しましょう！",
+  "badges": {
+    "firstStep": {
+      "title": "第一歩",
+      "description": "最初の山を登る"
+    },
+    "tenDone": {
+      "title": "10山達成",
+      "description": "10の山を登る"
+    },
+    "halfWay": {
+      "title": "半分達成",
+      "description": "50の山を登る"
+    },
+    "fiveStarClimber": {
+      "title": "5星登山者",
+      "description": "5星の山を登る"
+    }
+  },
+  "regions": {
+    "北海道": "北海道",
+    "東北": "東北",
+    "関東": "関東",
+    "中部": "中部",
+    "関西": "関西",
+    "中国": "中国",
+    "四国": "四国",
+    "九州": "九州"
+  }
 }

--- a/src/lib/i18n/messages/zh.json
+++ b/src/lib/i18n/messages/zh.json
@@ -13,5 +13,38 @@
   "dateSetToToday": "日期已设置为今天。您可以编辑。",
   "dateInvalidFuture": "不能设置未来日期",
   "dateSaved": "日期保存成功",
-  "dateCleared": "日期已清除"
+  "dateCleared": "日期已清除",
+  "progressByDifficulty": "难度进度",
+  "achievements": "成就",
+  "earned": "已获得",
+  "locked": "未获得",
+  "completeMountainsToEarn": "攀登山峰来获得成就！",
+  "badges": {
+    "firstStep": {
+      "title": "第一步",
+      "description": "攀登第一座山峰"
+    },
+    "tenDone": {
+      "title": "十山完成",
+      "description": "攀登10座山峰"
+    },
+    "halfWay": {
+      "title": "半程达成",
+      "description": "攀登50座山峰"
+    },
+    "fiveStarClimber": {
+      "title": "五星登山者",
+      "description": "攀登一座五星山峰"
+    }
+  },
+  "regions": {
+    "北海道": "北海道",
+    "東北": "东北",
+    "関東": "关东",
+    "中部": "中部",
+    "関西": "关西",
+    "中国": "中国",
+    "四国": "四国",
+    "九州": "九州"
+  }
 }


### PR DESCRIPTION
- Add translations for 'Progress by Difficulty' and 'Achievements' sections
- Add translations for badge titles and descriptions (First Step, Ten Done, etc.)
- Add translations for region names (北海道, 関東, 中部, etc.)
- Update DifficultyBreakdown component to use i18n
- Update BadgeDisplay component to use i18n
- Update dashboard to translate region names
- Support English, Japanese, and Chinese translations
- All hardcoded English text now properly translates when switching languages